### PR TITLE
feat: add toggle switch in settings to toggle mirror origin

### DIFF
--- a/DankDisplayMirrorSettings.qml
+++ b/DankDisplayMirrorSettings.qml
@@ -27,6 +27,34 @@ PluginSettings {
 
     StyledRect {
         width: parent.width
+        height: behaviorColumn.implicitHeight + Theme.spacingL * 2
+        radius: Theme.cornerRadius
+        color: Theme.surfaceContainerHigh
+
+        Column {
+            id: behaviorColumn
+            anchors.fill: parent
+            anchors.margins: Theme.spacingL
+            spacing: Theme.spacingM
+
+            StyledText {
+                text: "Mirror Behavior"
+                font.pixelSize: Theme.fontSizeMedium
+                font.weight: Font.Medium
+                color: Theme.surfaceText
+            }
+
+            ToggleSetting {
+                settingKey: "mirrorFromCurrentScreen"
+                label: "Mirror From Current Display"
+                description: "Mirror the current display onto the selected display (instead of mirroring the selected display onto the current one) (default behavior on most Desktop Environments)"
+                defaultValue: false
+            }
+        }
+    }
+
+    StyledRect {
+        width: parent.width
         height: refreshColumn.implicitHeight + Theme.spacingL * 2
         radius: Theme.cornerRadius
         color: Theme.surfaceContainerHigh

--- a/DankDisplayMirrorWidget.qml
+++ b/DankDisplayMirrorWidget.qml
@@ -9,14 +9,18 @@ import qs.Modules.Plugins
 
 PluginComponent {
     id: root
+    pluginId: "displayMirror"
+    pluginService: PluginService
 
     property bool autoRefresh: pluginData.autoRefresh ?? false
     property int refreshInterval: pluginData.refreshInterval || 30
-
+    property bool mirrorFromCurrentScreen: pluginData.mirrorFromCurrentScreen ?? false
+    
     property var monitors: []
     property bool isLoading: false
     property bool justStartedMirror: false  // Track if we just started a mirror vs checking status
     property string lastStartedSource: ""   // Track which source we just started mirroring
+    property string lastStartedTarget: ""   // Track which target we just started mirroring
     property bool wlMirrorInstalled: true
     
     // Use shared singleton state so all widget instances see the same values
@@ -176,17 +180,25 @@ PluginComponent {
 
             isLoading = true
             justStartedMirror = true
-            lastStartedSource = outputName
             lastMirrorError = ""
             lastMirrorOutput = ""
             
             // Close the Control Center using the proper PopoutService API
             // This prevents CC from staying open below the fullscreen wl-mirror window
             PopoutService.closeControlCenter()
+
+            // Launch wl-mirror in background
+            const sourceOutput = root.mirrorFromCurrentScreen ? root.currentFocusedOutput : outputName
+            const finalTarget = root.mirrorFromCurrentScreen ? outputName : root.currentFocusedOutput
             
-            // Launch wl-mirror in background, echo its PID
-            const safeOutput = outputName.replace(/"/g, '\\"')
-            mirrorProcess.command = ["sh", "-c", "wl-mirror --fullscreen \"" + safeOutput + "\" >/dev/null 2>&1 & echo $!"]
+            const safeSource = sourceOutput.replace(/"/g, '\\"')
+            const safeTarget = finalTarget.replace(/"/g, '\\"')
+            
+            mirrorProcess.command = ["sh", "-c", "wl-mirror --fullscreen-output \"" + safeTarget + "\" \"" + safeSource + "\" >/dev/null 2>&1 & echo $!"]
+            
+            // Track the actual source and target used (for addMirror when process starts)
+            lastStartedSource = sourceOutput
+            lastStartedTarget = finalTarget
             mirrorProcess.running = true
         })
     }
@@ -319,8 +331,8 @@ PluginComponent {
                 const pid = data.trim()
                 lastMirrorOutput = pid
                 // Add mirror with source and target we just started
-                if (lastStartedSource && pid && currentFocusedOutput) {
-                    root.addMirror(pid, lastStartedSource, currentFocusedOutput)
+                if (lastStartedSource && pid && lastStartedTarget) {
+                    root.addMirror(pid, lastStartedSource, lastStartedTarget)
                 }
             }
         }
@@ -429,7 +441,7 @@ PluginComponent {
             id: detailPopout
 
             headerText: "Display Mirror"
-            detailsText: hasActiveMirrors ? (activeMirrorCount + " display" + (activeMirrorCount > 1 ? "s" : "") + " currently being mirrored.") : (currentFocusedOutput ? "Choose an output to start mirroring on the current display" : "Select a display to mirror")
+            detailsText: hasActiveMirrors ? (activeMirrorCount + " display" + (activeMirrorCount > 1 ? "s" : "") + " currently being mirrored.") : (currentFocusedOutput ? (root.mirrorFromCurrentScreen ? "Choose an output to mirror the current display onto (" + currentFocusedOutput + "):": "Choose an output to mirror onto the current display (" + currentFocusedOutput + "):") : "Select a display to mirror")
             showCloseButton: true
 
             onVisibleChanged: {
@@ -733,7 +745,7 @@ PluginComponent {
                                         }
 
                                         StyledText {
-                                            text: "Click to mirror"
+                                            text: root.mirrorFromCurrentScreen ? "Mirror this display → " + modelData : "Mirror " + modelData + " → this display"
                                             font.pixelSize: Theme.fontSizeSmall
                                             color: Theme.surfaceVariantText
                                         }
@@ -961,7 +973,7 @@ PluginComponent {
                 // Info text (CC detail)
                 StyledText {
                     width: parent.width - Theme.spacingM * 2
-                    text: hasActiveMirrors ? (activeMirrorCount + " display" + (activeMirrorCount > 1 ? "s" : "") + " currently being mirrored.") : (currentFocusedOutput ? "Choose an output to start mirroring on the current display" : "Select a display to mirror")
+            text: hasActiveMirrors ? (activeMirrorCount + " display" + (activeMirrorCount > 1 ? "s" : "") + " currently being mirrored.") : (currentFocusedOutput ? (root.mirrorFromCurrentScreen ? "Choose an output to mirror " + currentFocusedOutput + " onto:" : "Choose an output to mirror on " + currentFocusedOutput + ":") : "Select a display to mirror")
                     font.pixelSize: Theme.fontSizeSmall
                     color: Theme.surfaceVariantText
                     wrapMode: Text.WordWrap
@@ -1128,7 +1140,7 @@ PluginComponent {
                                     }
 
                                     StyledText {
-                                        text: "Click to start mirroring"
+                                        text: mirrorFromCurrentScreen ? "Click to mirror on this display" : "Click to mirror this display"
                                         font.pixelSize: Theme.fontSizeSmall
                                         color: Theme.surfaceVariantText
                                     }

--- a/DankDisplayMirrorWidget.qml
+++ b/DankDisplayMirrorWidget.qml
@@ -261,7 +261,7 @@ PluginComponent {
 
     Process {
         id: monitorProcess
-        command: ["sh", "-c", "niri msg outputs | grep '^Output' | cut -d'(' -f 2 | cut -d')' -f 1"]
+        command: ["sh", "-c", "niri msg outputs | grep '^Output' | awk -F'[()]' '{print $(NF-1)}'"]
         running: false
 
         property var monitorList: []
@@ -301,7 +301,7 @@ PluginComponent {
 
     Process {
         id: focusedOutputProcess
-        command: ["sh", "-c", "niri msg focused-output 2>/dev/null | grep -oP '(?<=\\().*(?=\\))' | head -1"]
+        command: ["sh", "-c", "niri msg focused-output 2>/dev/null | grep '^Output' | awk -F'[()]' '{print $(NF-1)}' | head -1"]
         running: false
 
         stdout: SplitParser {

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A DankMaterialShell plugin that provides an easy interface to mirror niri displa
 - **One-Click Mirroring** - Start screen mirroring with a single click
 - **Quick Stop** - Stop active mirror sessions instantly
 - **Bar Widget** - Show mirroring status and control from the DankBar
+- **Mirror Behavior** - Choose in which direction you want to mirror your display (from or to the selected display)
 
 ## Installation
 

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "displayMirror",
     "name": "Display Mirror",
     "description": "Mirror niri displays using wl-mirror from the control center and bar",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "author": "jfchenier",
     "icon": "screen_share",
     "type": "widget",


### PR DESCRIPTION
This PR adds a toggle switch in the settings that adds the ability to toggle between mirroring from the current display or mirroring to the current display.
This feature was introduced because it is sometimes more natural to mirror from a display (eg. giving a presentation).

<img width="526" height="318" alt="image" src="https://github.com/user-attachments/assets/ded85d57-7b2b-40cc-a540-e777087a5dce" />

#### Setting toggled off
<img width="519" height="244" alt="image" src="https://github.com/user-attachments/assets/27d45202-cf51-40aa-8a51-792788ca8f86" />
<img width="524" height="258" alt="image" src="https://github.com/user-attachments/assets/29334027-8878-4bea-aed6-cb418c2cd27c" />


#### Setting toggled on
<img width="519" height="244" alt="image" src="https://github.com/user-attachments/assets/251cba02-b833-4fa2-843d-60db1c29e45b" />
<img width="524" height="258" alt="image" src="https://github.com/user-attachments/assets/ab374c53-3db8-45aa-863b-121422c52216" />

Resolves #1 
