### PR TITLE
Add support to other compositors using DMS abstractions

### DIFF
--- a/DankDisplayMirrorSettings.qml
+++ b/DankDisplayMirrorSettings.qml
@@ -93,7 +93,7 @@ PluginSettings {
             }
 
             StyledText {
-                text: "This plugin allows you to mirror displays using wl-mirror. It's particularly useful for screen sharing or duplicating your screen.\n\nRequirements:\n• wl-mirror (install via package manager)\n• niri compositor\n• Wayland session\n\nUsage:\n1. Open Control Center\n2. Click the Display Mirror tile\n3. Select the display you want to mirror\n4. A new window will open showing the mirrored content\n5. Click 'Stop Mirror' to end the session"
+                text: "This plugin allows you to mirror displays using wl-mirror. It's particularly useful for screen sharing or duplicating your screen.\n\nRequirements:\n• wl-mirror (install via package manager)\n• A DMS-supported compositor (niri, Hyprland, sway, dwl, …)\n• Wayland session\n\nUsage:\n1. Open Control Center\n2. Click the Display Mirror tile\n3. Select the display you want to mirror\n4. A new window will open showing the mirrored content\n5. Click 'Stop Mirror' to end the session"
                 font.pixelSize: Theme.fontSizeSmall
                 color: Theme.surfaceVariantText
                 wrapMode: Text.WordWrap
@@ -135,7 +135,7 @@ PluginSettings {
             }
 
             StyledText {
-                text: "To manually control wl-mirror:\n\nList outputs:\n  niri msg outputs\n\nStart mirroring:\n  wl-mirror <output-name>\n\nStop all mirrors:\n  killall wl-mirror"
+                text: "To manually control wl-mirror:\n\nList outputs:\n  dms randr\n\nStart mirroring:\n  wl-mirror <output-name>\n\nStop all mirrors:\n  killall wl-mirror"
                 font.pixelSize: Theme.fontSizeSmall
                 color: Theme.surfaceVariantText
                 wrapMode: Text.WordWrap

--- a/DankDisplayMirrorWidget.qml
+++ b/DankDisplayMirrorWidget.qml
@@ -13,7 +13,8 @@ PluginComponent {
     property bool autoRefresh: pluginData.autoRefresh ?? false
     property int refreshInterval: pluginData.refreshInterval || 30
 
-    property var monitors: []
+    // Reactive list of all connected outputs. Updates automatically on hotplug, so no manual refresh is required.
+    property var monitors: Quickshell.screens.map(s => s.name)
     property bool isLoading: false
     property bool justStartedMirror: false  // Track if we just started a mirror vs checking status
     property string lastStartedSource: ""   // Track which source we just started mirroring
@@ -138,13 +139,19 @@ PluginComponent {
         }
     }
 
-    function refreshMonitors() {
-        isLoading = true
-        monitorProcess.running = true
+    function detectFocusedOutput() {
+        const screen = CompositorService.getFocusedScreen()
+        if (screen && screen.name) {
+            root.currentFocusedOutput = screen.name
+            console.log("DisplayMirror: Detected focused output:", screen.name)
+        } else {
+            console.warn("DisplayMirror: Could not detect focused output")
+        }
     }
 
-    function detectFocusedOutput() {
-        focusedOutputProcess.running = true
+    function refreshMonitors() {
+        // monitors is a reactive binding on Quickshell.screens, so just re-detect which output is focused
+        detectFocusedOutput()
     }
 
     function startMirror(outputName) {
@@ -243,68 +250,6 @@ PluginComponent {
             if (exitCode !== 0) {
                 root.wlMirrorInstalled = false
                 console.warn("DisplayMirror: wl-mirror is not installed")
-            }
-        }
-    }
-
-    Process {
-        id: monitorProcess
-        command: ["sh", "-c", "niri msg outputs | grep '^Output' | cut -d'(' -f 2 | cut -d')' -f 1"]
-        running: false
-
-        property var monitorList: []
-
-        stdout: SplitParser {
-            splitMarker: "\n"
-            onRead: data => {
-                // Each read is now a single line thanks to splitMarker
-                const line = data.trim()
-                if (line.length > 0) {
-                    monitorProcess.monitorList.push(line)
-                    console.log("DisplayMirror: Added monitor:", line, "- total now:", monitorProcess.monitorList.length)
-                }
-            }
-        }
-
-        onRunningChanged: {
-            if (running) {
-                monitorList = []
-            }
-        }
-
-        onExited: (exitCode, exitStatus) => {
-            root.isLoading = false
-            if (exitCode === 0) {
-                console.log("DisplayMirror: Process exited, collected", monitorProcess.monitorList.length, "monitors")
-                // Force QML to recognize array change by creating new array reference
-                root.monitors = []
-                root.monitors = monitorProcess.monitorList.slice()
-                console.log("DisplayMirror: Set root.monitors to", root.monitors.length, "items:", JSON.stringify(root.monitors))
-            } else {
-                console.warn("DisplayMirror: Failed to get monitors, exit code:", exitCode)
-                root.monitors = []
-            }
-        }
-    }
-
-    Process {
-        id: focusedOutputProcess
-        command: ["sh", "-c", "niri msg focused-output 2>/dev/null | grep -oP '(?<=\\().*(?=\\))' | head -1"]
-        running: false
-
-        stdout: SplitParser {
-            onRead: data => {
-                const output = data.trim()
-                if (output.length > 0) {
-                    root.currentFocusedOutput = output
-                    console.log("DisplayMirror: Detected focused output:", output)
-                }
-            }
-        }
-
-        onExited: (exitCode, exitStatus) => {
-            if (exitCode !== 0) {
-                console.warn("DisplayMirror: Failed to detect focused output, exit code:", exitCode)
             }
         }
     }
@@ -681,7 +626,7 @@ PluginComponent {
                                 }
 
                                 StyledText {
-                                    text: "Make sure niri is running"
+                                    text: "Make sure a DMS compatible compositor is running"
                                     font.pixelSize: Theme.fontSizeSmall
                                     color: Theme.surfaceVariantText
                                     anchors.horizontalCenter: parent.horizontalCenter
@@ -1180,7 +1125,7 @@ PluginComponent {
                         }
 
                         StyledText {
-                            text: "Make sure niri is running"
+                            text: "Make sure a DMS compatible compositor is running"
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.surfaceVariantText
                             anchors.horizontalCenter: parent.horizontalCenter

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Display Mirror
 
-A DankMaterialShell plugin that provides an easy interface to mirror niri displays using wl-mirror from the control center and bar.
+A DankMaterialShell plugin that provides an easy interface to mirror displays using wl-mirror from the control center and bar. It works on any compositor supported by DMS (niri, Hyprland, sway, dwl, …) using DMS abstractions.
 
 ![Display Mirror Screenshot](https://github.com/jfchenier/dms-display-mirror/blob/main/assets/screenshot.png)
 
@@ -44,7 +44,7 @@ Then:
 
 - **DankMaterialShell** >= 0.1.0
 - **wl-mirror** - Wayland screen mirroring utility
-- **niri** compositor
+- A **DMS-supported compositor** (niri, Hyprland, sway, dwl, …)
 
 ### Installing wl-mirror
 
@@ -94,9 +94,9 @@ sudo make install
 
 ## Compatibility
 
-- **Compositors**: Niri only
+- **Compositors**: Any DMS-supported compositor (niri, Hyprland, sway, dwl, …)
 - **Distros**: Universal - works on any Linux distribution
-- **Dependencies**: wl-mirror, niri
+- **Dependencies**: wl-mirror
 
 ## Contributing
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "id": "displayMirror",
     "name": "Display Mirror",
-    "description": "Mirror niri displays using wl-mirror from the control center and bar",
+    "description": "Mirror displays using wl-mirror from the control center and bar",
     "version": "1.0.0",
     "author": "jfchenier",
     "icon": "screen_share",


### PR DESCRIPTION
Make the plugin universal for other compositors by leveraging DMS abstractions.
Now there is no shell calls to `niri msg.
Tested on Niri and MangoWM